### PR TITLE
FEAT: change to net 8. 

### DIFF
--- a/DataFileHeader/DataFileHeader.csproj
+++ b/DataFileHeader/DataFileHeader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
In usage, some references packages aren't compatible with netstandard 2.1, hence why this is changing.